### PR TITLE
muxer: prepend prefix to segments

### DIFF
--- a/muxer_part.go
+++ b/muxer_part.go
@@ -9,8 +9,8 @@ import (
 	"github.com/bluenviron/mediacommon/pkg/formats/fmp4"
 )
 
-func fmp4PartName(id uint64) string {
-	return "part" + strconv.FormatUint(id, 10)
+func partName(prefix string, id uint64) string {
+	return prefix + "_part" + strconv.FormatUint(id, 10) + ".mp4"
 }
 
 type muxerPart struct {
@@ -21,6 +21,7 @@ type muxerPart struct {
 	id                  uint64
 	storage             storage.Part
 
+	name                string
 	isIndependent       bool
 	videoSamples        []*fmp4.PartSample
 	audioSamples        []*fmp4.PartSample
@@ -36,6 +37,7 @@ func newMuxerPart(
 	videoTrack *Track,
 	audioTrack *Track,
 	audioTrackTimeScale uint32,
+	prefix string,
 	id uint64,
 	storage storage.Part,
 ) *muxerPart {
@@ -46,6 +48,7 @@ func newMuxerPart(
 		audioTrackTimeScale: audioTrackTimeScale,
 		id:                  id,
 		storage:             storage,
+		name:                partName(prefix, id),
 	}
 
 	if videoTrack == nil {
@@ -55,8 +58,8 @@ func newMuxerPart(
 	return p
 }
 
-func (p *muxerPart) name() string {
-	return fmp4PartName(p.id)
+func (p *muxerPart) getName() string {
+	return p.name
 }
 
 func (p *muxerPart) reader() (io.ReadCloser, error) {

--- a/muxer_segment.go
+++ b/muxer_segment.go
@@ -3,8 +3,16 @@ package gohlslib
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"time"
 )
+
+func segmentName(prefix string, id uint64, mp4 bool) string {
+	if mp4 {
+		return prefix + "_seg" + strconv.FormatUint(id, 10) + ".mp4"
+	}
+	return prefix + "_seg" + strconv.FormatUint(id, 10) + ".ts"
+}
 
 type muxerSegment interface {
 	close()

--- a/muxer_segment_mpegts.go
+++ b/muxer_segment_mpegts.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"strconv"
 	"time"
 
 	"github.com/bluenviron/gohlslib/pkg/storage"
@@ -42,6 +41,7 @@ func newMuxerSegmentMPEGTS(
 	writerAudioTrack *mpegts.Track,
 	switchableWriter *switchableWriter,
 	writer *mpegts.Writer,
+	prefix string,
 	factory storage.Factory,
 ) (*muxerSegmentMPEGTS, error) {
 	t := &muxerSegmentMPEGTS{
@@ -50,11 +50,11 @@ func newMuxerSegmentMPEGTS(
 		writerAudioTrack: writerAudioTrack,
 		writer:           writer,
 		startNTP:         startNTP,
-		name:             "seg" + strconv.FormatUint(id, 10),
+		name:             segmentName(prefix, id, false),
 	}
 
 	var err error
-	t.storage, err = factory.NewFile(t.name + ".ts")
+	t.storage, err = factory.NewFile(t.name)
 	if err != nil {
 		return nil, err
 	}

--- a/muxer_segmenter_mpegts.go
+++ b/muxer_segmenter_mpegts.go
@@ -29,6 +29,7 @@ type muxerSegmenterMPEGTS struct {
 	segmentMaxSize  uint64
 	videoTrack      *Track
 	audioTrack      *Track
+	prefix          string
 	factory         storage.Factory
 	onSegmentReady  func(muxerSegment)
 
@@ -47,6 +48,7 @@ func newMuxerSegmenterMPEGTS(
 	segmentMaxSize uint64,
 	videoTrack *Track,
 	audioTrack *Track,
+	prefix string,
 	factory storage.Factory,
 	onSegmentReady func(muxerSegment),
 ) *muxerSegmenterMPEGTS {
@@ -55,6 +57,7 @@ func newMuxerSegmenterMPEGTS(
 		segmentMaxSize:  segmentMaxSize,
 		videoTrack:      videoTrack,
 		audioTrack:      audioTrack,
+		prefix:          prefix,
 		factory:         factory,
 		onSegmentReady:  onSegmentReady,
 	}
@@ -141,6 +144,7 @@ func (m *muxerSegmenterMPEGTS) writeH26x(
 			m.writerAudioTrack,
 			m.switchableWriter,
 			m.writer,
+			m.prefix,
 			m.factory)
 		if err != nil {
 			return err
@@ -171,6 +175,7 @@ func (m *muxerSegmenterMPEGTS) writeH26x(
 				m.writerAudioTrack,
 				m.switchableWriter,
 				m.writer,
+				m.prefix,
 				m.factory,
 			)
 			if err != nil {
@@ -211,6 +216,7 @@ func (m *muxerSegmenterMPEGTS) writeMPEG4Audio(ntp time.Time, pts time.Duration,
 				m.writerAudioTrack,
 				m.switchableWriter,
 				m.writer,
+				m.prefix,
 				m.factory,
 			)
 			if err != nil {
@@ -234,6 +240,7 @@ func (m *muxerSegmenterMPEGTS) writeMPEG4Audio(ntp time.Time, pts time.Duration,
 					m.writerAudioTrack,
 					m.switchableWriter,
 					m.writer,
+					m.prefix,
 					m.factory,
 				)
 				if err != nil {

--- a/muxer_test.go
+++ b/muxer_test.go
@@ -223,12 +223,12 @@ func TestMuxerVideoAudio(t *testing.T) {
 					`#EXT-X-MEDIA-SEQUENCE:0\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:4.00000,\n` +
-					`(seg0\.ts)\n` +
+					`(.*?_seg0\.ts)\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:1.00000,\n` +
-					`(seg1\.ts)\n$`)
+					`(.*?_seg1\.ts)\n$`)
+				require.Regexp(t, re, string(byts))
 				ma := re.FindStringSubmatch(string(byts))
-				require.NotEqual(t, 0, len(ma))
 
 				_, h, err := doRequest(m, ma[2], "", "", "")
 				require.NoError(t, err)
@@ -240,62 +240,64 @@ func TestMuxerVideoAudio(t *testing.T) {
 					`#EXT-X-VERSION:9\n` +
 					`#EXT-X-TARGETDURATION:4\n` +
 					`#EXT-X-MEDIA-SEQUENCE:0\n` +
-					`#EXT-X-MAP:URI="init.mp4"\n` +
+					`#EXT-X-MAP:URI="(.*?_init.mp4)"\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:4.00000,\n` +
-					`(seg0\.mp4)\n` +
+					`(.*?_seg0\.mp4)\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:1.00000,\n` +
-					`(seg1\.mp4)\n$`)
+					`(.*?_seg1\.mp4)\n$`)
+				require.Regexp(t, re, string(byts))
 				ma := re.FindStringSubmatch(string(byts))
-				require.NotEqual(t, 0, len(ma))
 
-				_, h, err := doRequest(m, "init.mp4", "", "", "")
+				_, h, err := doRequest(m, ma[1], "", "", "")
 				require.NoError(t, err)
 				require.Equal(t, "video/mp4", h.Get("Content-Type"))
 				require.Equal(t, "max-age=30", h.Get("Cache-Control"))
 
-				_, h, err = doRequest(m, ma[2], "", "", "")
+				_, h, err = doRequest(m, ma[3], "", "", "")
 				require.NoError(t, err)
 				require.Equal(t, "video/mp4", h.Get("Content-Type"))
 				require.Equal(t, "max-age=3600", h.Get("Cache-Control"))
 
 			case "lowLatency":
-				require.Equal(t,
-					"#EXTM3U\n"+
-						"#EXT-X-VERSION:9\n"+
-						"#EXT-X-TARGETDURATION:4\n"+
-						"#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=5.00000,CAN-SKIP-UNTIL=24.00000\n"+
-						"#EXT-X-PART-INF:PART-TARGET=2.00000\n"+
-						"#EXT-X-MEDIA-SEQUENCE:2\n"+
-						"#EXT-X-MAP:URI=\"init.mp4\"\n"+
-						"#EXT-X-GAP\n"+
-						"#EXTINF:4.00000,\n"+
-						"gap.mp4\n"+
-						"#EXT-X-GAP\n"+
-						"#EXTINF:4.00000,\n"+
-						"gap.mp4\n"+
-						"#EXT-X-GAP\n"+
-						"#EXTINF:4.00000,\n"+
-						"gap.mp4\n"+
-						"#EXT-X-GAP\n"+
-						"#EXTINF:4.00000,\n"+
-						"gap.mp4\n"+
-						"#EXT-X-GAP\n"+
-						"#EXTINF:4.00000,\n"+
-						"gap.mp4\n"+
-						"#EXT-X-PROGRAM-DATE-TIME:2010-01-01T01:01:02Z\n"+
-						"#EXT-X-PART:DURATION=2.00000,URI=\"part0.mp4\",INDEPENDENT=YES\n"+
-						"#EXT-X-PART:DURATION=2.00000,URI=\"part1.mp4\"\n"+
-						"#EXTINF:4.00000,\n"+
-						"seg7.mp4\n"+
-						"#EXT-X-PROGRAM-DATE-TIME:2010-01-01T01:01:06Z\n"+
-						"#EXT-X-PART:DURATION=1.00000,URI=\"part3.mp4\",INDEPENDENT=YES\n"+
-						"#EXTINF:1.00000,\n"+
-						"seg8.mp4\n"+
-						"#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"part4.mp4\"\n", string(byts))
+				re := regexp.MustCompile(
+					`^#EXTM3U\n` +
+						`#EXT-X-VERSION:9\n` +
+						`#EXT-X-TARGETDURATION:4\n` +
+						`#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=5.00000,CAN-SKIP-UNTIL=24.00000\n` +
+						`#EXT-X-PART-INF:PART-TARGET=2.00000\n` +
+						`#EXT-X-MEDIA-SEQUENCE:2\n` +
+						`#EXT-X-MAP:URI="(.*?_init\.mp4)"\n` +
+						`#EXT-X-GAP\n` +
+						`#EXTINF:4.00000,\n` +
+						`gap.mp4\n` +
+						`#EXT-X-GAP\n` +
+						`#EXTINF:4.00000,\n` +
+						`gap.mp4\n` +
+						`#EXT-X-GAP\n` +
+						`#EXTINF:4.00000,\n` +
+						`gap.mp4\n` +
+						`#EXT-X-GAP\n` +
+						`#EXTINF:4.00000,\n` +
+						`gap.mp4\n` +
+						`#EXT-X-GAP\n` +
+						`#EXTINF:4.00000,\n` +
+						`gap.mp4\n` +
+						`#EXT-X-PROGRAM-DATE-TIME:2010-01-01T01:01:02Z\n` +
+						`#EXT-X-PART:DURATION=2.00000,URI="(.*?_part0\.mp4)",INDEPENDENT=YES\n` +
+						`#EXT-X-PART:DURATION=2.00000,URI="(.*?_part1\.mp4)"\n` +
+						`#EXTINF:4.00000,\n` +
+						`(.*?_seg7\.mp4)\n` +
+						`#EXT-X-PROGRAM-DATE-TIME:2010-01-01T01:01:06Z\n` +
+						`#EXT-X-PART:DURATION=1.00000,URI="(.*?_part3\.mp4)",INDEPENDENT=YES\n` +
+						`#EXTINF:1.00000,\n` +
+						`(.*?_seg8\.mp4)\n` +
+						`#EXT-X-PRELOAD-HINT:TYPE=PART,URI="(.*?_part4\.mp4)"\n$`)
+				require.Regexp(t, re, string(byts))
+				ma := re.FindStringSubmatch(string(byts))
 
-				_, h, err := doRequest(m, "part3.mp4", "", "", "")
+				_, h, err := doRequest(m, ma[4], "", "", "")
 				require.NoError(t, err)
 				require.Equal(t, "video/mp4", h.Get("Content-Type"))
 				require.Equal(t, "max-age=3600", h.Get("Cache-Control"))
@@ -303,7 +305,7 @@ func TestMuxerVideoAudio(t *testing.T) {
 				recv := make(chan struct{})
 
 				go func() {
-					_, _, err := doRequest(m, "part4.mp4", "", "", "")
+					_, _, err := doRequest(m, ma[5], "", "", "")
 					require.NoError(t, err)
 					close(recv)
 				}()
@@ -391,44 +393,43 @@ func TestMuxerVideoOnly(t *testing.T) {
 			byts, _, err = doRequest(m, "stream.m3u8", "", "", "")
 			require.NoError(t, err)
 
-			var ma []string
+			var re *regexp.Regexp
 			if ca == "mpegts" {
-				re := regexp.MustCompile(`^#EXTM3U\n` +
+				re = regexp.MustCompile(`^#EXTM3U\n` +
 					`#EXT-X-VERSION:3\n` +
 					`#EXT-X-ALLOW-CACHE:NO\n` +
 					`#EXT-X-TARGETDURATION:4\n` +
 					`#EXT-X-MEDIA-SEQUENCE:0\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:4.00000,\n` +
-					`(seg0\.ts)\n` +
+					`(.*?_seg0\.ts)\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:1.00000,\n` +
-					`(seg1\.ts)\n$`)
-				ma = re.FindStringSubmatch(string(byts))
+					`(.*?_seg1\.ts)\n$`)
 			} else {
-				re := regexp.MustCompile(`^#EXTM3U\n` +
+				re = regexp.MustCompile(`^#EXTM3U\n` +
 					`#EXT-X-VERSION:9\n` +
 					`#EXT-X-TARGETDURATION:4\n` +
 					`#EXT-X-MEDIA-SEQUENCE:0\n` +
-					`#EXT-X-MAP:URI="init.mp4"\n` +
+					`#EXT-X-MAP:URI="(.*?_init.mp4)"\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:4.00000,\n` +
-					`(seg0\.mp4)\n` +
+					`(.*?_seg0\.mp4)\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:1.00000,\n` +
-					`(seg1\.mp4)\n$`)
-				ma = re.FindStringSubmatch(string(byts))
+					`(.*?_seg1\.mp4)\n$`)
 			}
-			require.NotEqual(t, 0, len(ma))
+			require.Regexp(t, re, string(byts))
+			ma := re.FindStringSubmatch(string(byts))
 
 			if ca == "mpegts" {
 				_, _, err := doRequest(m, ma[2], "", "", "")
 				require.NoError(t, err)
 			} else {
-				_, _, err := doRequest(m, "init.mp4", "", "", "")
+				_, _, err := doRequest(m, ma[1], "", "", "")
 				require.NoError(t, err)
 
-				_, _, err = doRequest(m, ma[2], "", "", "")
+				_, _, err = doRequest(m, ma[3], "", "", "")
 				require.NoError(t, err)
 			}
 		})
@@ -501,41 +502,40 @@ func TestMuxerAudioOnly(t *testing.T) {
 			byts, _, err = doRequest(m, "stream.m3u8", "", "", "")
 			require.NoError(t, err)
 
-			var ma []string
+			var re *regexp.Regexp
 			if ca == "mpegts" {
-				re := regexp.MustCompile(`^#EXTM3U\n` +
+				re = regexp.MustCompile(`^#EXTM3U\n` +
 					`#EXT-X-VERSION:3\n` +
 					`#EXT-X-ALLOW-CACHE:NO\n` +
 					`#EXT-X-TARGETDURATION:1\n` +
 					`#EXT-X-MEDIA-SEQUENCE:0\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:1.00000,\n` +
-					`(seg0\.ts)\n$`)
-				ma = re.FindStringSubmatch(string(byts))
+					`(.*?_seg0\.ts)\n$`)
 			} else {
-				re := regexp.MustCompile(`^#EXTM3U\n` +
+				re = regexp.MustCompile(`^#EXTM3U\n` +
 					`#EXT-X-VERSION:9\n` +
 					`#EXT-X-TARGETDURATION:1\n` +
 					`#EXT-X-MEDIA-SEQUENCE:0\n` +
-					`#EXT-X-MAP:URI="init.mp4"\n` +
+					`#EXT-X-MAP:URI="(.*?_init.mp4)"\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:1.00000,\n` +
-					`(seg0\.mp4)\n` +
+					`(.*?_seg0\.mp4)\n` +
 					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 					`#EXTINF:1.00000,\n` +
-					`(seg1\.mp4)\n$`)
-				ma = re.FindStringSubmatch(string(byts))
+					`(.*?_seg1\.mp4)\n$`)
 			}
-			require.NotEqual(t, 0, len(ma))
+			require.Regexp(t, re, string(byts))
+			ma := re.FindStringSubmatch(string(byts))
 
 			if ca == "mpegts" {
 				_, _, err := doRequest(m, ma[2], "", "", "")
 				require.NoError(t, err)
 			} else {
-				_, _, err := doRequest(m, "init.mp4", "", "", "")
+				_, _, err := doRequest(m, ma[1], "", "", "")
 				require.NoError(t, err)
 
-				_, _, err = doRequest(m, ma[2], "", "", "")
+				_, _, err = doRequest(m, ma[3], "", "", "")
 				require.NoError(t, err)
 			}
 		})
@@ -622,9 +622,9 @@ func TestMuxerDoubleRead(t *testing.T) {
 		`#EXT-X-MEDIA-SEQUENCE:0\n` +
 		`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
 		`#EXTINF:2.00000,\n` +
-		`(seg0\.ts)\n$`)
+		`(.*?_seg0\.ts)\n$`)
+	require.Regexp(t, re, string(byts))
 	ma := re.FindStringSubmatch(string(byts))
-	require.NotEqual(t, 0, len(ma))
 
 	byts1, _, err := doRequest(m, ma[2], "", "", "")
 	require.NoError(t, err)
@@ -702,25 +702,64 @@ func TestMuxerSaveToDisk(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			if ca != "mpegts" {
-				_, err = os.ReadFile(filepath.Join(dir, "init.mp4"))
-				require.NoError(t, err)
-			}
-
-			var ext string
-			if ca == "mpegts" {
-				ext = "ts"
-			} else {
-				ext = "mp4"
-			}
-
-			_, err = os.ReadFile(filepath.Join(dir, "seg0."+ext))
+			err = m.WriteH26x(testTime, 3*time.Second, [][]byte{
+				{5}, // IDR
+				{2},
+			})
 			require.NoError(t, err)
 
-			m.Close()
+			byts, _, err := doRequest(m, "stream.m3u8", "", "", "")
+			require.NoError(t, err)
 
-			_, err = os.ReadFile(filepath.Join(dir, "seg0."+ext))
-			require.Error(t, err)
+			var re *regexp.Regexp
+			if ca == "mpegts" {
+				re = regexp.MustCompile(`^#EXTM3U\n` +
+					`#EXT-X-VERSION:3\n` +
+					`#EXT-X-ALLOW-CACHE:NO\n` +
+					`#EXT-X-TARGETDURATION:2\n` +
+					`#EXT-X-MEDIA-SEQUENCE:0\n` +
+					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
+					`#EXTINF:2.00000,\n` +
+					`(.*?_seg0\.ts)\n` +
+					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
+					`#EXTINF:1.00000,\n` +
+					`(.*?_seg1\.ts)\n$`)
+			} else {
+				re = regexp.MustCompile(`^#EXTM3U\n` +
+					`#EXT-X-VERSION:9\n` +
+					`#EXT-X-TARGETDURATION:2\n` +
+					`#EXT-X-MEDIA-SEQUENCE:0\n` +
+					`#EXT-X-MAP:URI="(.*?_init.mp4)"\n` +
+					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
+					`#EXTINF:2.00000,\n` +
+					`(.*?_seg0\.mp4)\n` +
+					`#EXT-X-PROGRAM-DATE-TIME:(.*?)\n` +
+					`#EXTINF:1.00000,\n` +
+					`(.*?_seg1\.mp4)\n$`)
+			}
+			require.Regexp(t, re, string(byts))
+			ma := re.FindStringSubmatch(string(byts))
+
+			if ca == "mpegts" {
+				_, err = os.ReadFile(filepath.Join(dir, ma[2]))
+				require.NoError(t, err)
+
+				m.Close()
+
+				_, err = os.ReadFile(filepath.Join(dir, ma[2]))
+				require.Error(t, err)
+			} else {
+				_, err = os.ReadFile(filepath.Join(dir, ma[1]))
+				require.NoError(t, err)
+
+				_, err = os.ReadFile(filepath.Join(dir, ma[3]))
+				require.NoError(t, err)
+
+				m.Close()
+
+				_, err = os.ReadFile(filepath.Join(dir, ma[3]))
+				require.Error(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This is needed to prevent usage of cached segments from previous muxing sessions