### PR TITLE
Removed randomAccess check when publishing FMP4 segments

### DIFF
--- a/muxer_segmenter_fmp4.go
+++ b/muxer_segmenter_fmp4.go
@@ -367,9 +367,8 @@ func (m *muxerSegmenterFMP4) writeVideo(
 	}
 
 	// switch segment
-	if randomAccess &&
-		((m.nextVideoSample.dts-m.currentSegment.startDTS) >= m.segmentDuration ||
-			forceSwitch) {
+	if (m.nextVideoSample.dts-m.currentSegment.startDTS) >= m.segmentDuration ||
+		forceSwitch {
 		err := m.currentSegment.finalize(m.nextVideoSample.dts)
 		if err != nil {
 			return err


### PR DESCRIPTION
In our use-case we have a camera which has a large GOP size which means we receive an IDR frame every 7 seconds. When we browse to the HLS endpoint our video starts to play after about 7 seconds and it doesn't start from the beginning of the video, but actually 7 seconds into the video. This is all using HLS variant lowLatancy.

When we check the requests and responses in our browser we see that the request to index.m3u8 takes about 7 seconds. After debugging the code I noticed that the code responsible for handling the index.m3u8 request waits for a minimum of 2 segments before it continues and returns the response. As our GOP size is 7 seconds this explains the long initial wait before our video starts.

As we can't change the GOP size in our cameras and the ffmpeg re-encoding solution doesn't really perform all that well, I looked for another solution which resulted in this PR. I removed the radomAccess (IDR frame) condition when publishing segments in muxer_segmenter_fmp4.go. 

Result: index.m3u8 requests takes less than a second now and the video starts to play almost immediately without seemingly any problems or hiccups. 

I figure this solution might not adhere to the specs of HLS, so I don't know if this is a valid solution or if we should look into something else to get better performance for our setup?

Thanks for looking into this