### PR TITLE
Start streaming parts before first completed segment in HLS Low Latency

### DIFF
--- a/muxer_segment.go
+++ b/muxer_segment.go
@@ -17,6 +17,7 @@ func segmentName(prefix string, id uint64, mp4 bool) string {
 type muxerSegment interface {
 	close()
 	getName() string
+	hasDuration() bool
 	getDuration() time.Duration
 	getSize() uint64
 	reader() (io.ReadCloser, error)
@@ -31,6 +32,10 @@ func (g muxerGap) close() {
 
 func (g muxerGap) getName() string {
 	return ""
+}
+
+func (g muxerGap) hasDuration() bool {
+	return true
 }
 
 func (g muxerGap) getDuration() time.Duration {

--- a/muxer_segment_mpegts.go
+++ b/muxer_segment_mpegts.go
@@ -75,6 +75,10 @@ func (t *muxerSegmentMPEGTS) getName() string {
 	return t.name
 }
 
+func (t *muxerSegmentMPEGTS) hasDuration() bool {
+	return t.endDTS > 0
+}
+
 func (t *muxerSegmentMPEGTS) getDuration() time.Duration {
 	return t.endDTS - *t.startDTS
 }

--- a/pkg/storage/file_disk.go
+++ b/pkg/storage/file_disk.go
@@ -76,5 +76,14 @@ func (s *fileDisk) Reader() (io.ReadCloser, error) {
 
 // Size implements File.
 func (s *fileDisk) Size() uint64 {
-	return s.finalSize
+	if s.finalSize > 0 {
+		return s.finalSize
+	}
+
+	var currentSize uint64 = 0
+	for _, part := range s.parts {
+		currentSize += uint64(len(part.buffer.Bytes()))
+	}
+
+	return currentSize
 }

--- a/pkg/storage/file_ram.go
+++ b/pkg/storage/file_ram.go
@@ -48,5 +48,14 @@ func (s *fileRAM) Reader() (io.ReadCloser, error) {
 
 // Size implements File.
 func (s *fileRAM) Size() uint64 {
-	return s.finalSize
+	if s.finalSize > 0 {
+		return s.finalSize
+	}
+
+	var currentSize uint64 = 0
+	for _, part := range s.parts {
+		currentSize += uint64(len(part.buffer.Bytes()))
+	}
+
+	return currentSize
 }


### PR DESCRIPTION
In #79 I disabled the randomAccess check to start streaming HLS low latency parts before the first segment was completed. This enabled us to display the video feed much faster as our video source GOP size is 20seconds.

The PR was rejected because it was creating segments without a starting IDR frame. 

This PR solves the same problem in a (hopefully) supported manner.
