### PR TITLE
muxer: fix nil deref when finalizing muxerSegmentFMP4 with no currentPart

### DIFF
--- a/muxer_segment_fmp4.go
+++ b/muxer_segment_fmp4.go
@@ -80,6 +80,10 @@ func (s *muxerSegmentFMP4) reader() (io.ReadCloser, error) {
 }
 
 func (s *muxerSegmentFMP4) finalize(nextDTS time.Duration) error {
+	if s.currentPart == nil {
+		return nil
+	}
+
 	if s.currentPart.videoSamples != nil || s.currentPart.audioSamples != nil {
 		err := s.currentPart.finalize(nextDTS)
 		if err != nil {


### PR DESCRIPTION
Playing an AV1 + AAC HLS stream published by OBS Studio via RTMP results in the following panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x560447ec0e43]
goroutine 663 [running]:
github.com/bluenviron/gohlslib.(*muxerSegmentFMP4).finalize(0xc0006101c0, 0x0)
        github.com/bluenviron/gohlslib@v1.2.1/muxer_segment_fmp4.go:83 +0x23
github.com/bluenviron/gohlslib.(*muxerSegmenterFMP4).close(0xc00016a240)
        github.com/bluenviron/gohlslib@v1.2.1/muxer_segmenter_fmp4.go:131 +0x29
github.com/bluenviron/gohlslib.(*Muxer).Close(0xc000404140)
        github.com/bluenviron/gohlslib@v1.2.1/muxer.go:202 +0x38
github.com/bluenviron/mediamtx/internal/servers/hls.(*muxer).runInner(0xc0002a0120, {0x560448714258, 0xc0003da500}, 0xc0011f3fa0?)
        github.com/bluenviron/mediamtx/internal/servers/hls/muxer.go:288 +0xb30
github.com/bluenviron/mediamtx/internal/servers/hls.(*muxer).run.func1.1.1()
        github.com/bluenviron/mediamtx/internal/servers/hls/muxer.go:140 +0x32
created by github.com/bluenviron/mediamtx/internal/servers/hls.(*muxer).run.func1.1 in goroutine 662
        github.com/bluenviron/mediamtx/internal/servers/hls/muxer.go:139 +0x170
```

This commit addresses the panic, but does not fix the underlying issue with this particular codec combination.