### PR TITLE
muxer: fix targetDuration bug

### DIFF
--- a/muxer_server.go
+++ b/muxer_server.go
@@ -29,9 +29,10 @@ func boolPtr(v bool) *bool {
 func targetDuration(segments []muxerSegment) int {
 	ret := int(0)
 
-	// EXTINF, when rounded to the nearest integer, must be <= EXT-X-TARGETDURATION
+	// The EXTINF duration of each Media Segment in the Playlist file MUST be less than or equal to the target duration;
+	// So, the target duration is the integer greater than or equal to the largest EXTINF duration in the Playlist file.
 	for _, sog := range segments {
-		v := int(math.Round(sog.getDuration().Seconds()))
+		v := int(math.Ceil(sog.getDuration().Seconds()))
 		if v > ret {
 			ret = v
 		}


### PR DESCRIPTION
The EXTINF duration of each Media Segment in the Playlist file MUST be less than or equal to the target duration;
So, the target duration is the integer greater than or equal to the largest EXTINF duration in the Playlist file.

gohlslib generate follow m3u8
```
#EXTM3U
#EXT-X-VERSION:9
#EXT-X-TARGETDURATION:1
#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=2.00000,CAN-SKIP-UNTIL=6.00000
#EXT-X-PART-INF:PART-TARGET=0.80000
#EXT-X-MEDIA-SEQUENCE:12241
#EXT-X-SKIP:SKIPPED-SEGMENTS=2
#EXTINF:1.26600,
e91d74de40eb_seg12243.mp4
#EXTINF:1.26700,
e91d74de40eb_seg12244.mp4
#EXTINF:1.06700,
e91d74de40eb_seg12245.mp4
#EXT-X-PROGRAM-DATE-TIME:2024-03-11T07:38:24.419Z
#EXT-X-PART:DURATION=0.80000,URI="e91d74de40eb_part24909.mp4",INDEPENDENT=YES
#EXT-X-PART:DURATION=0.50000,URI="e91d74de40eb_part24910.mp4"
#EXTINF:1.30000,
e91d74de40eb_seg12246.mp4
#EXT-X-PROGRAM-DATE-TIME:2024-03-11T07:38:25.72Z
#EXT-X-PART:DURATION=0.80000,URI="e91d74de40eb_part24911.mp4",INDEPENDENT=YES
#EXT-X-PART:DURATION=0.23300,URI="e91d74de40eb_part24912.mp4"
#EXTINF:1.03300,
e91d74de40eb_seg12247.mp4
#EXT-X-PART:DURATION=0.80000,URI="e91d74de40eb_part24913.mp4",INDEPENDENT=YES
#EXT-X-PRELOAD-HINT:TYPE=PART,URI="e91d74de40eb_part24914.mp4"
```

`#EXT-X-TARGETDURATION:1` is wrong. 
`#EXT-X-TARGETDURATION:1` should be `#EXT-X-TARGETDURATION:2`