### PR TITLE
Ignore LL-HLS requests for segments that have already expired

### DIFF
--- a/muxer_server.go
+++ b/muxer_server.go
@@ -14,12 +14,12 @@ import (
 	"github.com/bluenviron/mediacommon/pkg/codecs/av1"
 	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
 	"github.com/bluenviron/mediacommon/pkg/codecs/h265"
+	"github.com/bluenviron/mediacommon/pkg/formats/fmp4"
+	"github.com/bluenviron/mediacommon/pkg/formats/fmp4/seekablebuffer"
 
 	"github.com/bluenviron/gohlslib/pkg/codecparams"
 	"github.com/bluenviron/gohlslib/pkg/codecs"
 	"github.com/bluenviron/gohlslib/pkg/playlist"
-	"github.com/bluenviron/mediacommon/pkg/formats/fmp4"
-	"github.com/bluenviron/mediacommon/pkg/formats/fmp4/seekablebuffer"
 )
 
 func boolPtr(v bool) *bool {
@@ -564,7 +564,7 @@ func (s *muxerServer) handleMediaPlaylist(msn string, part string, skip string, 
 				// exceeds the last Partial Segment in the current Playlist by the
 				// Advance Part Limit, then the server SHOULD immediately return Bad
 				// Request, such as HTTP 400.
-				if msnint > (s.nextSegmentID + 1) {
+				if msnint > (s.nextSegmentID+1) || msnint < (s.nextSegmentID-uint64(len(s.segments)-1)) {
 					w.WriteHeader(http.StatusBadRequest)
 					return nil, nil
 				}

--- a/muxer_test.go
+++ b/muxer_test.go
@@ -1102,11 +1102,10 @@ func TestMuxerExpiredSegment(t *testing.T) {
 	}
 }
 
-type mockSegmentMP4 struct {
-}
+type mockSegmentMP4 struct{}
 
 func (m mockSegmentMP4) close() {
-	return
+	// do nothing
 }
 
 func (m mockSegmentMP4) getName() string {


### PR DESCRIPTION
If an LL-HLS request comes in for a segment that has already expired, it will always wait until the session is terminated.
If the segment is already in an inaccessible state, it is handled so that it does not wait any longer.