### PR TITLE
add EXT-X-KEY tag support to playlist parser

### DIFF
--- a/pkg/playlist/media_key.go
+++ b/pkg/playlist/media_key.go
@@ -1,0 +1,117 @@
+package playlist
+
+import (
+	"fmt"
+
+	"github.com/bluenviron/gohlslib/v2/pkg/playlist/primitives"
+)
+
+type MediaKeyMethod string
+
+const (
+	MediaKeyMethodNone      = "NONE"
+	MediaKeyMethodAES128    = "AES-128"
+	MediaKeyMethodSampleAes = "SAMPLE-AES"
+)
+
+// MediaKey is a EXT-X-KEY tag.
+type MediaKey struct {
+	// METHOD
+	// required
+	Method MediaKeyMethod
+
+	// URI is required unless METHOD is NONE
+	URI string
+
+	// IV
+	IV string
+
+	// KEYFORMAT
+	KeyFormat string
+
+	// KEYFORMATVERSIONS
+	KeyFormatVersions string
+}
+
+func (t *MediaKey) unmarshal(v string) error {
+	attrs, err := primitives.AttributesUnmarshal(v)
+	if err != nil {
+		return err
+	}
+
+	for key, val := range attrs {
+		switch key {
+		case "METHOD":
+			km := MediaKeyMethod(val)
+			if km != MediaKeyMethodNone &&
+				km != MediaKeyMethodAES128 &&
+				km != MediaKeyMethodSampleAes {
+				return fmt.Errorf("invalid method: %s", val)
+			}
+			t.Method = km
+
+		case "URI":
+			t.URI = val
+
+		case "IV":
+			t.IV = val
+
+		case "KEYFORMAT":
+			t.KeyFormat = val
+
+		case "KEYFORMATVERSIONS":
+			t.KeyFormatVersions = val
+		}
+	}
+
+	switch t.Method {
+	case MediaKeyMethodAES128, MediaKeyMethodSampleAes:
+		if t.URI == "" {
+			return fmt.Errorf("URI is required for method %s", t.Method)
+		}
+	default:
+	}
+
+	return nil
+}
+
+func (t MediaKey) marshal() string {
+	ret := "#EXT-X-KEY:METHOD=" + string(t.Method)
+
+	// If the encryption method is NONE, other attributes MUST NOT be present.
+	if t.Method != MediaKeyMethodNone {
+		ret += ",URI=\"" + t.URI + "\""
+
+		if t.IV != "" {
+			ret += ",IV=" + t.IV
+		}
+
+		if t.KeyFormat != "" {
+			ret += ",KEYFORMAT=\"" + t.KeyFormat + "\""
+		}
+
+		if t.KeyFormatVersions != "" {
+			ret += ",KEYFORMATVERSIONS=\"" + t.KeyFormatVersions + "\""
+		}
+	}
+
+	ret += "\n"
+
+	return ret
+}
+
+func (t *MediaKey) Equal(key *MediaKey) bool {
+	if t == key {
+		return true
+	}
+
+	if key == nil {
+		return false
+	}
+
+	return t.Method == key.Method &&
+		t.URI == key.URI &&
+		t.IV == key.IV &&
+		t.KeyFormat == key.KeyFormat &&
+		t.KeyFormatVersions == key.KeyFormatVersions
+}

--- a/pkg/playlist/media_key.go
+++ b/pkg/playlist/media_key.go
@@ -6,12 +6,14 @@ import (
 	"github.com/bluenviron/gohlslib/v2/pkg/playlist/primitives"
 )
 
+// MediaKeyMethod is the encryption method used for the media segments.
 type MediaKeyMethod string
 
+// standard encryption methods
 const (
 	MediaKeyMethodNone      = "NONE"
 	MediaKeyMethodAES128    = "AES-128"
-	MediaKeyMethodSampleAes = "SAMPLE-AES"
+	MediaKeyMethodSampleAES = "SAMPLE-AES"
 )
 
 // MediaKey is a EXT-X-KEY tag.
@@ -45,7 +47,7 @@ func (t *MediaKey) unmarshal(v string) error {
 			km := MediaKeyMethod(val)
 			if km != MediaKeyMethodNone &&
 				km != MediaKeyMethodAES128 &&
-				km != MediaKeyMethodSampleAes {
+				km != MediaKeyMethodSampleAES {
 				return fmt.Errorf("invalid method: %s", val)
 			}
 			t.Method = km
@@ -65,7 +67,7 @@ func (t *MediaKey) unmarshal(v string) error {
 	}
 
 	switch t.Method {
-	case MediaKeyMethodAES128, MediaKeyMethodSampleAes:
+	case MediaKeyMethodAES128, MediaKeyMethodSampleAES:
 		if t.URI == "" {
 			return fmt.Errorf("URI is required for method %s", t.Method)
 		}
@@ -100,6 +102,7 @@ func (t MediaKey) marshal() string {
 	return ret
 }
 
+// Equal checks if two MediaKey objects are equal.
 func (t *MediaKey) Equal(key *MediaKey) bool {
 	if t == key {
 		return true

--- a/pkg/playlist/media_segment.go
+++ b/pkg/playlist/media_segment.go
@@ -31,6 +31,9 @@ type MediaSegment struct {
 	// EXT-X-BITRATE
 	Bitrate *int
 
+	// EXT-X-KEY
+	Key *MediaKey
+
 	// EXT-X-BYTERANGE
 	ByteRangeLength *uint64
 	ByteRangeStart  *uint64

--- a/pkg/playlist/media_test.go
+++ b/pkg/playlist/media_test.go
@@ -225,6 +225,150 @@ main.mp4
 			Endlist: true,
 		},
 	},
+	{
+		"key-basic",
+		`#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=AES-128,URI="key.bin"
+#EXTINF:6.00000,
+segment1.ts
+#EXTINF:6.00000,
+segment2.ts`,
+		`#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=AES-128,URI="key.bin"
+#EXTINF:6.00000,
+segment1.ts
+#EXTINF:6.00000,
+segment2.ts
+`,
+		Media{
+			Version:        3,
+			TargetDuration: 6,
+			Segments: []*MediaSegment{
+				{
+					Duration: 6 * time.Second,
+					URI:      "segment1.ts",
+					Key: &MediaKey{
+						Method: MediaKeyMethodAES128,
+						URI:    "key.bin",
+					},
+				},
+				{
+					Duration: 6 * time.Second,
+					URI:      "segment2.ts",
+					Key: &MediaKey{
+						Method: MediaKeyMethodAES128,
+						URI:    "key.bin",
+					},
+				},
+			},
+		},
+	},
+	{
+		"key-with-iv",
+		`#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=AES-128,URI="key.bin",IV=0x1234567890abcdef1234567890abcdef
+#EXTINF:6.00000,
+segment1.ts
+`,
+		`#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=AES-128,URI="key.bin",IV=0x1234567890abcdef1234567890abcdef
+#EXTINF:6.00000,
+segment1.ts
+`,
+		Media{
+			Version:        3,
+			TargetDuration: 6,
+			Segments: []*MediaSegment{
+				{
+					Duration: 6 * time.Second,
+					URI:      "segment1.ts",
+					Key: &MediaKey{
+						Method: MediaKeyMethodAES128,
+						URI:    "key.bin",
+						IV:     "0x1234567890abcdef1234567890abcdef",
+					},
+				},
+			},
+		},
+	},
+	{
+		"key-with-format",
+		`#EXTM3U
+#EXT-X-VERSION:5
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=SAMPLE-AES,URI="key.bin",KEYFORMAT="com.apple.streamingkeydelivery",KEYFORMATVERSIONS="1"
+#EXTINF:6.00000,
+segment1.ts
+`,
+		`#EXTM3U
+#EXT-X-VERSION:5
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=SAMPLE-AES,URI="key.bin",KEYFORMAT="com.apple.streamingkeydelivery",KEYFORMATVERSIONS="1"
+#EXTINF:6.00000,
+segment1.ts
+`,
+		Media{
+			Version:        5,
+			TargetDuration: 6,
+			Segments: []*MediaSegment{
+				{
+					Duration: 6 * time.Second,
+					URI:      "segment1.ts",
+					Key: &MediaKey{
+						Method:            MediaKeyMethodSampleAES,
+						URI:               "key.bin",
+						KeyFormat:         "com.apple.streamingkeydelivery",
+						KeyFormatVersions: "1",
+					},
+				},
+			},
+		},
+	},
+	{
+		"key-none",
+		`#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=NONE
+#EXTINF:6.00000,
+segment1.ts`,
+		`#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=NONE
+#EXTINF:6.00000,
+segment1.ts
+`,
+		Media{
+			Version:        3,
+			TargetDuration: 6,
+			Segments: []*MediaSegment{
+				{
+					Duration: 6 * time.Second,
+					URI:      "segment1.ts",
+					Key: &MediaKey{
+						Method: MediaKeyMethodNone,
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestMediaUnmarshal(t *testing.T) {

--- a/pkg/playlist/testdata/fuzz/FuzzMediaUnmarshal/32c9b70f1dcd40a8
+++ b/pkg/playlist/testdata/fuzz/FuzzMediaUnmarshal/32c9b70f1dcd40a8
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("#EXTM3U\n#EXT-X-KEY:0")

--- a/pkg/playlist/testdata/fuzz/FuzzMediaUnmarshal/bdfd84d77054b242
+++ b/pkg/playlist/testdata/fuzz/FuzzMediaUnmarshal/bdfd84d77054b242
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("#EXTM3U\n#EXT-X-KEY:METHOD=AES-128")

--- a/pkg/playlist/testdata/fuzz/FuzzMediaUnmarshal/eba654116c9d19f6
+++ b/pkg/playlist/testdata/fuzz/FuzzMediaUnmarshal/eba654116c9d19f6
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("#EXTM3U\n#EXT-X-KEY:METHOD=")


### PR DESCRIPTION
Media Segments MAY be encrypted.

Add support for EXT-X-KEY tag in m3u8 playlist parser.

Ref: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.4
