### PR TITLE
Support Verkada EXTINF Tags

### DIFF
--- a/pkg/playlist/media.go
+++ b/pkg/playlist/media.go
@@ -276,7 +276,7 @@ func (m *Media) Unmarshal(buf []byte) error {
 		case strings.HasPrefix(line, "#EXTINF:"):
 			line = line[len("#EXTINF:"):]
 			parts := strings.SplitN(line, ",", 2)
-			if len(parts) != 2 {
+			if len(parts) < 1 || len(parts) > 2 {
 				return fmt.Errorf("invalid EXTINF: %s", line)
 			}
 
@@ -287,7 +287,12 @@ func (m *Media) Unmarshal(buf []byte) error {
 			}
 
 			curSegment.Duration = time.Duration(d)
-			curSegment.Title = strings.TrimSpace(parts[1])
+
+			if len(parts) == 2 {
+				curSegment.Title = strings.TrimSpace(parts[1])
+			} else {
+				curSegment.Title = ""
+			}
 
 			curSegment.Key = curKey
 

--- a/pkg/playlist/media_test.go
+++ b/pkg/playlist/media_test.go
@@ -369,6 +369,37 @@ segment1.ts
 			},
 		},
 	},
+	{
+		"key-none",
+		`#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=NONE
+#EXTINF:4.00000
+segment1.ts`,
+		`#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=NONE
+#EXTINF:6.00000
+segment1.ts
+`,
+		Media{
+			Version:        3,
+			TargetDuration: 4,
+			Segments: []*MediaSegment{
+				{
+					Duration: 4 * time.Second,
+					URI:      "segment1.ts",
+					Key: &MediaKey{
+						Method: MediaKeyMethodNone,
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestMediaUnmarshal(t *testing.T) {


### PR DESCRIPTION
### Context

Verkada is quickly becoming one of the larger camera companies and hosts a very well designed API for accessing camera metadata and video feeds. Unfortunately their attention to detail stopped at the HLS Playlist file as they currently do not follow the spec exactly and do not include a `,` character in the EXTINF tags, instead only having the segment length float value.

I have reached out to their developers but unfortunately it does not appear as though this change is likely to happen. As the impact of loosening this parsing should be minimal and does not break any existing HLS sources, I hope you will consider this PR as it will add support for many thousands of cameras we are attempting to ingest via their platform