### PR TITLE
muxer: add support for setting a `BaseURL`

### DIFF
--- a/muxer.go
+++ b/muxer.go
@@ -181,6 +181,8 @@ type Muxer struct {
 	// This decreases performance, since saving segments on disk is less performant
 	// than saving them on RAM, but allows to preserve RAM.
 	Directory string
+	// The base URL used to prefix every entry in the playlist.
+	BaseURL string
 
 	//
 	// callbacks (all optional)
@@ -354,6 +356,7 @@ func (m *Muxer) Start() error {
 			tracks:         m.mtracks,
 			id:             "main",
 			nextSegmentID:  nextSegmentID,
+			baseURL:        m.BaseURL,
 		}
 		err = stream.initialize()
 		if err != nil {
@@ -411,6 +414,7 @@ func (m *Muxer) Start() error {
 				language:       track.Language,
 				isDefault:      isDefault,
 				nextSegmentID:  nextSegmentID,
+				baseURL:        m.BaseURL,
 			}
 			err = stream.initialize()
 			if err != nil {


### PR DESCRIPTION
Some user might want to host the segments at a cdn to do this they will need to be able to modify the `uri`s specified in the playlist by setting a `BaseURL` to the file this PR implements that use case.