### PR TITLE
feat(muxer): add support for H265 and MPEG1 audio codecs

### DIFF
--- a/client_stream_processor_mpegts.go
+++ b/client_stream_processor_mpegts.go
@@ -158,7 +158,7 @@ func (p *clientStreamProcessorMPEGTS) initializeReader(ctx context.Context, firs
 
 	for _, track := range p.reader.Tracks() {
 		switch track.Codec.(type) {
-		case *mpegts.CodecH264, *mpegts.CodecMPEG4Audio:
+		case *mpegts.CodecH264, *mpegts.CodecH265, *mpegts.CodecMPEG4Audio:
 			supportedTracks = append(supportedTracks, track)
 		}
 	}
@@ -239,6 +239,11 @@ func (p *clientStreamProcessorMPEGTS) initializeReader(ctx context.Context, firs
 		switch track.track.Codec.(type) {
 		case *codecs.H264:
 			p.reader.OnDataH264(mpegtsTrack, func(pts int64, dts int64, au [][]byte) error {
+				return processSample(pts, dts, au)
+			})
+
+		case *codecs.H265:
+			p.reader.OnDataH265(mpegtsTrack, func(pts int64, dts int64, au [][]byte) error {
 				return processSample(pts, dts, au)
 			})
 

--- a/muxer.go
+++ b/muxer.go
@@ -241,18 +241,22 @@ func (m *Muxer) Start() error {
 				if hasVideo {
 					return fmt.Errorf("the MPEG-TS variant of HLS supports a single video track only")
 				}
-				if _, ok := track.Codec.(*codecs.H264); !ok {
-					return fmt.Errorf(
-						"the MPEG-TS variant of HLS supports H264 video only")
+				switch track.Codec.(type) {
+				case *codecs.H264, *codecs.H265:
+					// ok
+				default:
+					return fmt.Errorf("the MPEG-TS variant of HLS supports H264/H265 video only")
 				}
 				hasVideo = true
 			} else {
 				if hasAudio {
 					return fmt.Errorf("the MPEG-TS variant of HLS supports a single audio track only")
 				}
-				if _, ok := track.Codec.(*codecs.MPEG4Audio); !ok {
-					return fmt.Errorf(
-						"the MPEG-TS variant of HLS supports MPEG-4 Audio only")
+				switch track.Codec.(type) {
+				case *codecs.MPEG4Audio, *codecs.MPEG1Audio:
+					// ok
+				default:
+					return fmt.Errorf("the MPEG-TS variant of HLS supports MPEG-4 Audio or MPEG-1 Audio only")
 				}
 				hasAudio = true
 			}
@@ -505,6 +509,16 @@ func (m *Muxer) WriteMPEG4Audio(
 	aus [][]byte,
 ) error {
 	return m.segmenter.writeMPEG4Audio(m.mtracksByTrack[track], ntp, pts, aus)
+}
+
+// WriteMPEG1Audio writes MPEG-1 Audio frames.
+func (m *Muxer) WriteMPEG1Audio(
+	track *Track,
+	ntp time.Time,
+	pts int64,
+	frames [][]byte,
+) error {
+	return m.segmenter.writeMPEG1Audio(m.mtracksByTrack[track], ntp, pts, frames)
 }
 
 // Handle handles a HTTP request.

--- a/pkg/codecs/from_mpegts.go
+++ b/pkg/codecs/from_mpegts.go
@@ -10,10 +10,16 @@ func FromMPEGTS(in mpegts.Codec) Codec {
 	case *mpegts.CodecH264:
 		return &H264{}
 
+	case *mpegts.CodecH265:
+		return &H265{}
+
 	case *mpegts.CodecMPEG4Audio:
 		return &MPEG4Audio{
 			Config: in.Config,
 		}
+
+	case *mpegts.CodecMPEG1Audio:
+		return &MPEG1Audio{}
 	}
 
 	return nil

--- a/pkg/codecs/mpeg1_audio.go
+++ b/pkg/codecs/mpeg1_audio.go
@@ -1,0 +1,10 @@
+package codecs
+
+// MPEG1Audio represents MPEG-1/2 Layer II/III audio (commonly MP3) for MPEG-TS HLS.
+// It carries raw MPEG audio frames and is only supported with the MPEG-TS variant.
+type MPEG1Audio struct{}
+
+// IsVideo implements Codec.
+func (MPEG1Audio) IsVideo() bool { return false }
+
+func (*MPEG1Audio) isCodec() {}

--- a/pkg/codecs/to_mpegts.go
+++ b/pkg/codecs/to_mpegts.go
@@ -8,10 +8,16 @@ func ToMPEGTS(in Codec) mpegts.Codec {
 	case *H264:
 		return &mpegts.CodecH264{}
 
+	case *H265:
+		return &mpegts.CodecH265{}
+
 	case *MPEG4Audio:
 		return &mpegts.CodecMPEG4Audio{
 			Config: in.Config,
 		}
+
+	case *MPEG1Audio:
+		return &mpegts.CodecMPEG1Audio{}
 	}
 
 	return nil


### PR DESCRIPTION
- Updated client stream processor to handle H265 codec in track initialization.
- Implemented writeH265 and writeMPEG1Audio methods in muxerSegmentMPEGTS.
- Enhanced muxer to support MPEG1 audio frames.
- Updated codec conversion functions to include H265 and MPEG1 audio.

This adds support for additional video and audio formats in the MPEG-TS variant.