### PR TITLE
client: prevent out-of-memory errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,9 +17,11 @@ import (
 )
 
 const (
-	clientMaxTracksPerStream    = 10
-	clientMPEGTSSampleQueueSize = 100
-	clientMaxDTSSystemDiff      = 10 * time.Second
+	clientMaxTracksPerStream     = 10
+	clientMPEGTSSampleQueueSize  = 100
+	clientMaxMPEGTSQueuedSamples = 1000
+	clientMaxDTSSystemDiff       = 10 * time.Second
+	clientMaxInboundPlaylistSize = 1 * 1024 * 1024
 )
 
 // ErrClientEOS is returned by Wait() when the stream has ended.

--- a/client_primary_downloader.go
+++ b/client_primary_downloader.go
@@ -63,7 +63,7 @@ func downloadPlaylist(
 		return nil, nil, fmt.Errorf("bad status code: %d", res.StatusCode)
 	}
 
-	byts, err := io.ReadAll(res.Body)
+	byts, err := io.ReadAll(io.LimitReader(res.Body, clientMaxInboundPlaylistSize))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client_stream_downloader.go
+++ b/client_stream_downloader.go
@@ -273,7 +273,7 @@ func (d *clientStreamDownloader) downloadPreloadHint(
 		return nil, fmt.Errorf("bad status code: %d", res.StatusCode)
 	}
 
-	byts, err := io.ReadAll(res.Body)
+	byts, err := io.ReadAll(io.LimitReader(res.Body, clientMaxInboundPlaylistSize))
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +319,7 @@ func (d *clientStreamDownloader) downloadSegment(
 		return nil, fmt.Errorf("bad status code: %d", res.StatusCode)
 	}
 
-	byts, err := io.ReadAll(res.Body)
+	byts, err := io.ReadAll(io.LimitReader(res.Body, clientMaxInboundPlaylistSize))
 	if err != nil {
 		return nil, err
 	}

--- a/client_stream_processor_mpegts.go
+++ b/client_stream_processor_mpegts.go
@@ -13,10 +13,6 @@ import (
 	"github.com/bluenviron/gohlslib/v2/pkg/codecs"
 )
 
-const (
-	clientMaxQueuedSamples = 1000
-)
-
 func mpegtsPickLeadingTrack(mpegtsTracks []*mpegts.Track) int {
 	// pick first video track
 	for i, track := range mpegtsTracks {
@@ -264,7 +260,7 @@ func (p *clientStreamProcessorMPEGTS) processSample(
 			return nil
 		}
 
-		if len(p.queuedSamples) >= clientMaxQueuedSamples {
+		if len(p.queuedSamples) >= clientMaxMPEGTSQueuedSamples {
 			return fmt.Errorf("too many queued samples")
 		}
 

--- a/examples/playlist-parser/main.go
+++ b/examples/playlist-parser/main.go
@@ -22,7 +22,7 @@ func main() {
 	defer req.Body.Close()
 
 	// download the playlist
-	byts, err := io.ReadAll(req.Body)
+	byts, err := io.ReadAll(io.LimitReader(req.Body, 1*1024*1024))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
set maximum size of body of incoming HTTP requests and responses.