### PR TITLE
muxer: generate init segment once

### DIFF
--- a/muxer.go
+++ b/muxer.go
@@ -21,7 +21,6 @@ const (
 	fmp4StartDTS               = 10 * time.Second
 	mpegtsSegmentMinAUCount    = 100
 	multivariantPlaylistMaxAge = "30"
-	initMaxAge                 = "30"
 	segmentMaxAge              = "3600"
 )
 
@@ -603,10 +602,9 @@ func (m *Muxer) rotatePartsInner(nextDTS time.Duration) error {
 func (m *Muxer) rotateSegments(
 	nextDTS time.Duration,
 	nextNTP time.Time,
-	force bool,
 ) error {
 	m.mutex.Lock()
-	err := m.rotateSegmentsInner(nextDTS, nextNTP, force)
+	err := m.rotateSegmentsInner(nextDTS, nextNTP)
 	m.mutex.Unlock()
 
 	if err != nil {
@@ -621,16 +619,15 @@ func (m *Muxer) rotateSegments(
 func (m *Muxer) rotateSegmentsInner(
 	nextDTS time.Duration,
 	nextNTP time.Time,
-	force bool,
 ) error {
-	err := m.leadingStream.rotateSegments(nextDTS, nextNTP, force)
+	err := m.leadingStream.rotateSegments(nextDTS, nextNTP)
 	if err != nil {
 		return err
 	}
 
 	for _, stream := range m.streams {
 		if !stream.isLeading {
-			err = stream.rotateSegments(nextDTS, nextNTP, force)
+			err = stream.rotateSegments(nextDTS, nextNTP)
 			if err != nil {
 				return err
 			}

--- a/muxer_segment.go
+++ b/muxer_segment.go
@@ -12,7 +12,6 @@ type muxerSegment interface {
 	getPath() string
 	getDuration() time.Duration
 	getSize() uint64
-	isFromForcedRotation() bool
 	reader() (io.ReadCloser, error)
 }
 
@@ -37,10 +36,6 @@ func (g muxerGap) getDuration() time.Duration {
 
 func (muxerGap) getSize() uint64 {
 	return 0
-}
-
-func (muxerGap) isFromForcedRotation() bool {
-	return false
 }
 
 func (muxerGap) reader() (io.ReadCloser, error) {

--- a/muxer_segment_fmp4.go
+++ b/muxer_segment_fmp4.go
@@ -8,13 +8,12 @@ import (
 )
 
 type muxerSegmentFMP4 struct {
-	prefix             string
-	storageFactory     storage.Factory
-	streamID           string
-	id                 uint64
-	startNTP           time.Time
-	startDTS           time.Duration
-	fromForcedRotation bool
+	prefix         string
+	storageFactory storage.Factory
+	streamID       string
+	id             uint64
+	startNTP       time.Time
+	startDTS       time.Duration
 
 	path    string
 	storage storage.File
@@ -49,10 +48,6 @@ func (s *muxerSegmentFMP4) getDuration() time.Duration {
 
 func (s *muxerSegmentFMP4) getSize() uint64 {
 	return s.storage.Size()
-}
-
-func (s *muxerSegmentFMP4) isFromForcedRotation() bool {
-	return s.fromForcedRotation
 }
 
 func (s *muxerSegmentFMP4) reader() (io.ReadCloser, error) {

--- a/muxer_segment_mpegts.go
+++ b/muxer_segment_mpegts.go
@@ -60,10 +60,6 @@ func (s *muxerSegmentMPEGTS) getSize() uint64 {
 	return s.storage.Size()
 }
 
-func (*muxerSegmentMPEGTS) isFromForcedRotation() bool {
-	return false
-}
-
 func (s *muxerSegmentMPEGTS) reader() (io.ReadCloser, error) {
 	return s.storage.Reader()
 }

--- a/muxer_segmenter.go
+++ b/muxer_segmenter.go
@@ -1,7 +1,6 @@
 package gohlslib
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
@@ -79,7 +78,7 @@ type fmp4AugmentedSample struct {
 
 type muxerSegmenterParent interface {
 	createFirstSegment(nextDTS time.Duration, nextNTP time.Time) error
-	rotateSegments(nextDTS time.Duration, nextNTP time.Time, force bool) error
+	rotateSegments(nextDTS time.Duration, nextNTP time.Time) error
 	rotateParts(nextDTS time.Duration) error
 }
 
@@ -89,7 +88,6 @@ type muxerSegmenter struct {
 	partMinDuration    time.Duration
 	parent             muxerSegmenterParent
 
-	pendingParamsChange            bool
 	fmp4SampleDurations            map[time.Duration]struct{} // low-latency only
 	fmp4AdjustedPartDuration       time.Duration              // low-latency only
 	fmp4FreezeAdjustedPartDuration bool                       // low-latency only
@@ -107,7 +105,6 @@ func (s *muxerSegmenter) writeAV1(
 	pts int64,
 	tu [][]byte,
 ) error {
-	codec := track.Codec.(*codecs.AV1)
 	randomAccess := false
 
 	for _, obu := range tu {
@@ -115,18 +112,7 @@ func (s *muxerSegmenter) writeAV1(
 
 		if typ == av1.OBUTypeSequenceHeader {
 			randomAccess = true
-
-			if !bytes.Equal(codec.SequenceHeader, obu) {
-				s.pendingParamsChange = true
-				codec.SequenceHeader = obu
-			}
 		}
-	}
-
-	paramsChanged := false
-	if randomAccess && s.pendingParamsChange {
-		s.pendingParamsChange = false
-		paramsChanged = true
 	}
 
 	ps := &fmp4.Sample{}
@@ -138,7 +124,6 @@ func (s *muxerSegmenter) writeAV1(
 	return s.fmp4WriteSample(
 		track,
 		randomAccess,
-		paramsChanged,
 		&fmp4AugmentedSample{
 			Sample: *ps,
 			dts:    pts,
@@ -158,43 +143,7 @@ func (s *muxerSegmenter) writeVP9(
 		return err
 	}
 
-	codec := track.Codec.(*codecs.VP9)
-	randomAccess := false
-
-	if !h.NonKeyFrame {
-		randomAccess = true
-
-		if v := h.Width(); v != codec.Width {
-			s.pendingParamsChange = true
-			codec.Width = v
-		}
-		if v := h.Height(); v != codec.Height {
-			s.pendingParamsChange = true
-			codec.Height = v
-		}
-		if h.Profile != codec.Profile {
-			s.pendingParamsChange = true
-			codec.Profile = h.Profile
-		}
-		if h.ColorConfig.BitDepth != codec.BitDepth {
-			s.pendingParamsChange = true
-			codec.BitDepth = h.ColorConfig.BitDepth
-		}
-		if v := h.ChromaSubsampling(); v != codec.ChromaSubsampling {
-			s.pendingParamsChange = true
-			codec.ChromaSubsampling = v
-		}
-		if h.ColorConfig.ColorRange != codec.ColorRange {
-			s.pendingParamsChange = true
-			codec.ColorRange = h.ColorConfig.ColorRange
-		}
-	}
-
-	paramsChanged := false
-	if randomAccess && s.pendingParamsChange {
-		s.pendingParamsChange = false
-		paramsChanged = true
-	}
+	randomAccess := (!h.NonKeyFrame)
 
 	// skip samples silently until we find a random access one
 	if !track.firstRandomAccessReceived {
@@ -207,7 +156,6 @@ func (s *muxerSegmenter) writeVP9(
 	return s.fmp4WriteSample(
 		track,
 		randomAccess,
-		paramsChanged,
 		&fmp4AugmentedSample{
 			Sample: fmp4.Sample{
 				IsNonSyncSample: !randomAccess,
@@ -225,7 +173,6 @@ func (s *muxerSegmenter) writeH265(
 	au [][]byte,
 ) error {
 	randomAccess := false
-	codec := track.Codec.(*codecs.H265)
 
 	for _, nalu := range au {
 		typ := h265.NALUType((nalu[0] >> 1) & 0b111111)
@@ -233,31 +180,7 @@ func (s *muxerSegmenter) writeH265(
 		switch typ {
 		case h265.NALUType_IDR_W_RADL, h265.NALUType_IDR_N_LP, h265.NALUType_CRA_NUT:
 			randomAccess = true
-
-		case h265.NALUType_VPS_NUT:
-			if !bytes.Equal(codec.VPS, nalu) {
-				s.pendingParamsChange = true
-				codec.VPS = nalu
-			}
-
-		case h265.NALUType_SPS_NUT:
-			if !bytes.Equal(codec.SPS, nalu) {
-				s.pendingParamsChange = true
-				codec.SPS = nalu
-			}
-
-		case h265.NALUType_PPS_NUT:
-			if !bytes.Equal(codec.PPS, nalu) {
-				s.pendingParamsChange = true
-				codec.PPS = nalu
-			}
 		}
-	}
-
-	paramsChanged := false
-	if randomAccess && s.pendingParamsChange {
-		s.pendingParamsChange = false
-		paramsChanged = true
 	}
 
 	// skip samples silently until we find a random access one
@@ -287,7 +210,6 @@ func (s *muxerSegmenter) writeH265(
 	return s.fmp4WriteSample(
 		track,
 		randomAccess,
-		paramsChanged,
 		&fmp4AugmentedSample{
 			Sample: *ps,
 			dts:    dts,
@@ -302,7 +224,6 @@ func (s *muxerSegmenter) writeH264(
 	au [][]byte,
 ) error {
 	randomAccess := false
-	codec := track.Codec.(*codecs.H264)
 	nonIDRPresent := false
 
 	for _, nalu := range au {
@@ -314,29 +235,11 @@ func (s *muxerSegmenter) writeH264(
 
 		case h264.NALUTypeNonIDR:
 			nonIDRPresent = true
-
-		case h264.NALUTypeSPS:
-			if !bytes.Equal(codec.SPS, nalu) {
-				s.pendingParamsChange = true
-				codec.SPS = nalu
-			}
-
-		case h264.NALUTypePPS:
-			if !bytes.Equal(codec.PPS, nalu) {
-				s.pendingParamsChange = true
-				codec.PPS = nalu
-			}
 		}
 	}
 
 	if !randomAccess && !nonIDRPresent {
 		return nil
-	}
-
-	paramsChanged := false
-	if randomAccess && s.pendingParamsChange {
-		s.pendingParamsChange = false
-		paramsChanged = true
 	}
 
 	// skip samples silently until we find a random access one
@@ -362,10 +265,9 @@ func (s *muxerSegmenter) writeH264(
 				return err
 			}
 		} else if randomAccess && // switch segment
-			((timestampToDuration(dts, track.ClockRate)-
-				track.stream.nextSegment.(*muxerSegmentMPEGTS).startDTS) >= s.segmentMinDuration ||
-				paramsChanged) {
-			err = s.parent.rotateSegments(timestampToDuration(dts, track.ClockRate), ntp, false)
+			((timestampToDuration(dts, track.ClockRate) -
+				track.stream.nextSegment.(*muxerSegmentMPEGTS).startDTS) >= s.segmentMinDuration) {
+			err = s.parent.rotateSegments(timestampToDuration(dts, track.ClockRate), ntp)
 			if err != nil {
 				return err
 			}
@@ -395,7 +297,6 @@ func (s *muxerSegmenter) writeH264(
 	return s.fmp4WriteSample(
 		track,
 		randomAccess,
-		paramsChanged,
 		&fmp4AugmentedSample{
 			Sample: *ps,
 			dts:    dts,
@@ -413,7 +314,6 @@ func (s *muxerSegmenter) writeOpus(
 		err := s.fmp4WriteSample(
 			track,
 			true,
-			false,
 			&fmp4AugmentedSample{
 				Sample: fmp4.Sample{
 					Payload: packet,
@@ -450,7 +350,7 @@ func (s *muxerSegmenter) writeMPEG4Audio(
 			} else if track.stream.nextSegment.(*muxerSegmentMPEGTS).audioAUCount >= mpegtsSegmentMinAUCount && // switch segment
 				(timestampToDuration(pts, track.ClockRate)-
 					track.stream.nextSegment.(*muxerSegmentMPEGTS).startDTS) >= s.segmentMinDuration {
-				err := s.parent.rotateSegments(timestampToDuration(pts, track.ClockRate), ntp, false)
+				err := s.parent.rotateSegments(timestampToDuration(pts, track.ClockRate), ntp)
 				if err != nil {
 					return err
 				}
@@ -481,7 +381,6 @@ func (s *muxerSegmenter) writeMPEG4Audio(
 		err := s.fmp4WriteSample(
 			track,
 			true,
-			false,
 			&fmp4AugmentedSample{
 				Sample: fmp4.Sample{
 					Payload: au,
@@ -545,7 +444,6 @@ func (s *muxerSegmenter) fmp4AdjustPartDuration(sampleDuration time.Duration) {
 func (s *muxerSegmenter) fmp4WriteSample(
 	track *muxerTrack,
 	randomAccess bool,
-	paramsChanged bool,
 	sample *fmp4AugmentedSample,
 ) error {
 	// add a starting DTS to avoid a negative BaseTime
@@ -599,22 +497,15 @@ func (s *muxerSegmenter) fmp4WriteSample(
 
 	if track.isLeading {
 		// switch segment
-		if randomAccess && (paramsChanged ||
-			(timestampToDuration(track.fmp4NextSample.dts, track.ClockRate)-
-				track.stream.nextSegment.(*muxerSegmentFMP4).startDTS) >= s.segmentMinDuration) {
+		if randomAccess && ((timestampToDuration(track.fmp4NextSample.dts, track.ClockRate) -
+			track.stream.nextSegment.(*muxerSegmentFMP4).startDTS) >= s.segmentMinDuration) {
 			err = s.parent.rotateSegments(timestampToDuration(track.fmp4NextSample.dts, track.ClockRate),
-				track.fmp4NextSample.ntp, paramsChanged)
+				track.fmp4NextSample.ntp)
 			if err != nil {
 				return err
 			}
 
-			// reset or freeze adjusted part duration
-			if paramsChanged {
-				s.fmp4FreezeAdjustedPartDuration = false
-				s.fmp4SampleDurations = make(map[time.Duration]struct{})
-			} else {
-				s.fmp4FreezeAdjustedPartDuration = true
-			}
+			s.fmp4FreezeAdjustedPartDuration = true
 
 			// switch part
 		} else if (s.variant == MuxerVariantLowLatency) &&

--- a/muxer_stream.go
+++ b/muxer_stream.go
@@ -577,7 +577,6 @@ func (s *muxerStream) generateAndCacheInitFile() error {
 		return err
 	}
 
-	s.initFilePresent = true
 	initFile := w.Bytes()
 
 	var contentType string
@@ -590,9 +589,7 @@ func (s *muxerStream) generateAndCacheInitFile() error {
 	s.server.registerPath(
 		initFilePath(s.prefix, s.id),
 		func(w http.ResponseWriter, _ *http.Request) {
-			// allow caching but use a small period in order to
-			// allow a stream to change track parameters
-			w.Header().Set("Cache-Control", "max-age="+initMaxAge)
+			w.Header().Set("Cache-Control", "max-age="+segmentMaxAge)
 			w.Header().Set("Content-Type", contentType)
 			w.WriteHeader(http.StatusOK)
 			w.Write(initFile)
@@ -625,13 +622,12 @@ func (s *muxerStream) createFirstSegment(
 		s.mpegtsSwitchableWriter.w = seg.bw
 	} else {
 		seg := &muxerSegmentFMP4{
-			prefix:             s.prefix,
-			storageFactory:     s.storageFactory,
-			streamID:           s.id,
-			id:                 s.nextSegmentID,
-			startNTP:           nextNTP,
-			startDTS:           nextDTS,
-			fromForcedRotation: false,
+			prefix:         s.prefix,
+			storageFactory: s.storageFactory,
+			streamID:       s.id,
+			id:             s.nextSegmentID,
+			startNTP:       nextNTP,
+			startDTS:       nextDTS,
 		}
 		err := seg.initialize()
 		if err != nil {
@@ -762,7 +758,6 @@ func (s *muxerStream) rotateParts(
 func (s *muxerStream) rotateSegments(
 	nextDTS time.Duration,
 	nextNTP time.Time,
-	force bool,
 ) error {
 	if s.variant != MuxerVariantMPEGTS {
 		err := s.rotateParts(nextDTS, false)
@@ -840,12 +835,12 @@ func (s *muxerStream) rotateSegments(
 		s.segmentDeleteCount++
 	}
 
-	// regenerate init files only if missing or codec parameters have changed
-	if s.variant != MuxerVariantMPEGTS && (!s.initFilePresent || segment.isFromForcedRotation()) {
+	if s.variant != MuxerVariantMPEGTS && !s.initFilePresent {
 		err = s.generateAndCacheInitFile()
 		if err != nil {
 			return err
 		}
+		s.initFilePresent = true
 	}
 
 	if s.variant == MuxerVariantMPEGTS { //nolint:dupl
@@ -868,13 +863,12 @@ func (s *muxerStream) rotateSegments(
 		s.mpegtsSwitchableWriter.w = seg.bw
 	} else {
 		seg := &muxerSegmentFMP4{
-			prefix:             s.prefix,
-			storageFactory:     s.storageFactory,
-			streamID:           s.id,
-			id:                 s.nextSegmentID,
-			startNTP:           nextNTP,
-			startDTS:           nextDTS,
-			fromForcedRotation: force,
+			prefix:         s.prefix,
+			storageFactory: s.storageFactory,
+			streamID:       s.id,
+			id:             s.nextSegmentID,
+			startNTP:       nextNTP,
+			startDTS:       nextDTS,
 		}
 		err = seg.initialize()
 		if err != nil {

--- a/muxer_test.go
+++ b/muxer_test.go
@@ -579,7 +579,7 @@ func TestMuxer(t *testing.T) {
 			_, h, err = doRequest(m, ma[1])
 			require.NoError(t, err)
 			require.Equal(t, "video/mp4", h.Get("Content-Type"))
-			require.Equal(t, "max-age=30", h.Get("Cache-Control"))
+			require.Equal(t, "max-age=3600", h.Get("Cache-Control"))
 
 			// segment 1
 			_, h, err = doRequest(m, ma[2])
@@ -606,7 +606,7 @@ func TestMuxer(t *testing.T) {
 			_, h, err = doRequest(m, ma[1])
 			require.NoError(t, err)
 			require.Equal(t, "audio/mp4", h.Get("Content-Type"))
-			require.Equal(t, "max-age=30", h.Get("Cache-Control"))
+			require.Equal(t, "max-age=3600", h.Get("Cache-Control"))
 
 			// segment 1
 			_, h, err = doRequest(m, ma[2])
@@ -1070,7 +1070,7 @@ func TestMuxerDynamicParams(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	bu, _, err := doRequest(m, "index.m3u8")
+	index1, _, err := doRequest(m, "index.m3u8")
 	require.NoError(t, err)
 	require.Equal(t, "#EXTM3U\n"+
 		"#EXT-X-VERSION:9\n"+
@@ -1078,7 +1078,7 @@ func TestMuxerDynamicParams(t *testing.T) {
 		"\n"+
 		"#EXT-X-STREAM-INF:BANDWIDTH=1144,AVERAGE-BANDWIDTH=1028,"+
 		"CODECS=\"avc1.42c028\",RESOLUTION=1920x1080,FRAME-RATE=30.000\n"+
-		"video1_stream.m3u8\n", string(bu))
+		"video1_stream.m3u8\n", string(index1))
 
 	byts, _, err := doRequest(m, "video1_stream.m3u8")
 	require.NoError(t, err)
@@ -1096,15 +1096,13 @@ func TestMuxerDynamicParams(t *testing.T) {
 	require.Regexp(t, re, string(byts))
 	ma := re.FindStringSubmatch(string(byts))
 
-	bu, _, err = doRequest(m, ma[1])
+	bu, _, err := doRequest(m, ma[1])
 	require.NoError(t, err)
 
-	func() {
-		var init fmp4.Init
-		err = init.Unmarshal(bytes.NewReader(bu))
-		require.NoError(t, err)
-		require.Equal(t, testSPS, init.Tracks[0].Codec.(*mp4codecs.H264).SPS)
-	}()
+	var init1 fmp4.Init
+	err = init1.Unmarshal(bytes.NewReader(bu))
+	require.NoError(t, err)
+	require.Equal(t, testSPS, init1.Tracks[0].Codec.(*mp4codecs.H264).SPS)
 
 	// SPS (720p)
 	testSPS2 := []byte{
@@ -1126,15 +1124,15 @@ func TestMuxerDynamicParams(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	bu, _, err = doRequest(m, "index.m3u8")
+	index2, _, err := doRequest(m, "index.m3u8")
 	require.NoError(t, err)
 	require.Equal(t, "#EXTM3U\n"+
 		"#EXT-X-VERSION:9\n"+
 		"#EXT-X-INDEPENDENT-SEGMENTS\n"+
 		"\n"+
 		"#EXT-X-STREAM-INF:BANDWIDTH=912,AVERAGE-BANDWIDTH=752,"+
-		"CODECS=\"avc1.64001f\",RESOLUTION=1280x720,FRAME-RATE=30.000\n"+
-		"video1_stream.m3u8\n", string(bu))
+		"CODECS=\"avc1.42c028\",RESOLUTION=1920x1080,FRAME-RATE=30.000\n"+
+		"video1_stream.m3u8\n", string(index2))
 
 	byts, _, err = doRequest(m, "video1_stream.m3u8")
 	require.NoError(t, err)
@@ -1157,10 +1155,10 @@ func TestMuxerDynamicParams(t *testing.T) {
 	bu, _, err = doRequest(m, ma[1])
 	require.NoError(t, err)
 
-	var init fmp4.Init
-	err = init.Unmarshal(bytes.NewReader(bu))
+	var init2 fmp4.Init
+	err = init2.Unmarshal(bytes.NewReader(bu))
 	require.NoError(t, err)
-	require.Equal(t, testSPS2, init.Tracks[0].Codec.(*mp4codecs.H264).SPS)
+	require.Equal(t, init1, init2)
 }
 
 func TestMuxerFMP4ZeroDuration(t *testing.T) {


### PR DESCRIPTION
Previously, the init segment was regenerated in case of codec parameter changes, but changing the init segment has been proved to cause video and audio discontinuities on iOS. Now the init file contains starting parameters only and never changes during the stream lifetime.