### PR TITLE
muxer: remove lower limit on AAC access unit count in MPEG-TS segments (#329)

### DIFF
--- a/muxer.go
+++ b/muxer.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	fmp4StartDTS               = 10 * time.Second
-	mpegtsSegmentMinAUCount    = 100
 	multivariantPlaylistMaxAge = "30"
 	segmentMaxAge              = "3600"
 )

--- a/muxer_segment_mpegts.go
+++ b/muxer_segment_mpegts.go
@@ -20,13 +20,12 @@ type muxerSegmentMPEGTS struct {
 	startNTP       time.Time
 	startDTS       time.Duration
 
-	storage      storage.File
-	storagePart  storage.Part
-	bw           *bufio.Writer
-	size         uint64
-	path         string
-	endDTS       time.Duration // available after finalize()
-	audioAUCount int
+	storage     storage.File
+	storagePart storage.Part
+	bw          *bufio.Writer
+	size        uint64
+	path        string
+	endDTS      time.Duration // available after finalize()
 }
 
 func (s *muxerSegmentMPEGTS) initialize() error {
@@ -127,10 +126,6 @@ func (s *muxerSegmentMPEGTS) writeMPEG4Audio(
 	)
 	if err != nil {
 		return err
-	}
-
-	if track.isLeading {
-		s.audioAUCount++
 	}
 
 	return nil

--- a/muxer_segmenter.go
+++ b/muxer_segmenter.go
@@ -425,9 +425,8 @@ func (s *muxerSegmenter) writeMPEG4Audio(
 				if err != nil {
 					return err
 				}
-			} else if track.stream.nextSegment.(*muxerSegmentMPEGTS).audioAUCount >= mpegtsSegmentMinAUCount && // switch segment
-				(timestampToDuration(pts, track.ClockRate)-
-					track.stream.nextSegment.(*muxerSegmentMPEGTS).startDTS) >= s.segmentMinDuration {
+			} else if (timestampToDuration(pts, track.ClockRate) -
+				track.stream.nextSegment.(*muxerSegmentMPEGTS).startDTS) >= s.segmentMinDuration { // switch segment
 				err := s.parent.rotateSegments(timestampToDuration(pts, track.ClockRate), ntp)
 				if err != nil {
 					return err

--- a/muxer_test.go
+++ b/muxer_test.go
@@ -479,7 +479,7 @@ func TestMuxer(t *testing.T) {
 				"#EXT-X-VERSION:3\n"+
 				"#EXT-X-INDEPENDENT-SEGMENTS\n"+
 				"\n"+
-				"#EXT-X-STREAM-INF:BANDWIDTH=225600,AVERAGE-BANDWIDTH=225600,CODECS=\"mp4a.40.2\"\n"+
+				"#EXT-X-STREAM-INF:BANDWIDTH=225600,AVERAGE-BANDWIDTH=151904,CODECS=\"mp4a.40.2\"\n"+
 				"main_stream.m3u8?key=value\n", string(byts))
 
 		case content == "audio" && variant == "fmp4":
@@ -561,11 +561,7 @@ func TestMuxer(t *testing.T) {
 			require.Equal(t, "no-cache", h.Get("Cache-Control"))
 
 		case "mpegts":
-			if content == "audio" {
-				require.Equal(t, "public, max-age=2", h.Get("Cache-Control"))
-			} else {
-				require.Equal(t, "public, max-age=1", h.Get("Cache-Control"))
-			}
+			require.Equal(t, "public, max-age=1", h.Get("Cache-Control"))
 
 		default:
 			require.Equal(t, "public, max-age=1", h.Get("Cache-Control"))
@@ -600,7 +596,10 @@ func TestMuxer(t *testing.T) {
 				`#EXT-X-MEDIA-SEQUENCE:0\n` +
 				`#EXT-X-PROGRAM-DATE-TIME:.*?\n` +
 				`#EXTINF:2.00000,\n` +
-				`(.*?_seg0\.ts\?key=value)\n$`)
+				`(.*?_seg0\.ts\?key=value)\n` +
+				`#EXT-X-PROGRAM-DATE-TIME:.*?\n` +
+				`#EXTINF:1.00000,\n` +
+				`(.*?_seg1\.ts\?key=value)\n$`)
 			require.Regexp(t, re, string(byts))
 
 		case variant == "fmp4" && (content == "video+audio" || content == "video"):


### PR DESCRIPTION
Fixes #329