### PR TITLE
muxer: discard tracks with non-standard clock rates

### DIFF
--- a/muxer.go
+++ b/muxer.go
@@ -116,19 +116,34 @@ func partPath(prefix string, streamID string, partID uint64) string {
 	return prefix + "_" + streamID + "_part" + strconv.FormatUint(partID, 10) + ".mp4"
 }
 
-func fmp4TimeScale(c codecs.Codec) uint32 {
+func codecRequiredClockRate(c codecs.Codec) int {
 	switch codec := c.(type) {
-	case *codecs.MPEG4Audio:
-		return uint32(codec.Config.SampleRate)
+	case *codecs.AV1:
+		return 90000
+
+	case *codecs.VP9:
+		return 90000
+
+	case *codecs.H265:
+		return 90000
+
+	case *codecs.H264:
+		return 90000
 
 	case *codecs.Opus:
 		return 48000
 
+	case *codecs.MPEG4Audio:
+		return codec.Config.SampleRate
+
 	case *codecs.FLAC:
-		return codec.StreamInfo.SampleRate
+		return int(codec.StreamInfo.SampleRate)
+
+	case *codecs.KLV:
+		return 90000
 	}
 
-	return 90000
+	return 0
 }
 
 type switchableWriter struct {
@@ -226,6 +241,15 @@ func (m *Muxer) Start() error {
 
 	if len(m.Tracks) == 0 {
 		return fmt.Errorf("at least one track must be provided")
+	}
+
+	// supporting non-standard clock rates requires some computations that we're not doing right now.
+	// it's not worth the effort, for now.
+	for i, track := range m.Tracks {
+		requiredClockRate := codecRequiredClockRate(track.Codec)
+		if track.ClockRate != requiredClockRate {
+			return fmt.Errorf("track %d requires clock rate %d, but is %d", i, requiredClockRate, track.ClockRate)
+		}
 	}
 
 	hasVideo := false

--- a/muxer_segment_mpegts.go
+++ b/muxer_segment_mpegts.go
@@ -93,8 +93,8 @@ func (s *muxerSegmentMPEGTS) writeH264(
 
 	err := s.mpegtsWriter.WriteH264(
 		track.mpegtsTrack,
-		multiplyAndDivide(pts, 90000, int64(track.ClockRate)),
-		multiplyAndDivide(dts, 90000, int64(track.ClockRate)),
+		pts,
+		dts,
 		au,
 	)
 	if err != nil {
@@ -144,7 +144,7 @@ func (s *muxerSegmentMPEGTS) writeKLV(
 
 	return s.mpegtsWriter.WriteKLV(
 		track.mpegtsTrack,
-		multiplyAndDivide(pts, 90000, int64(track.ClockRate)),
+		pts,
 		data,
 	)
 }

--- a/muxer_segmenter.go
+++ b/muxer_segmenter.go
@@ -452,8 +452,7 @@ func (s *muxerSegmenter) writeMPEG4Audio(
 	for i, au := range aus {
 		auNTP := ntp.Add(time.Duration(i) * mpeg4audio.SamplesPerAccessUnit *
 			time.Second / time.Duration(sampleRate))
-		auPTS := pts + int64(i)*mpeg4audio.SamplesPerAccessUnit*
-			int64(track.ClockRate)/int64(sampleRate)
+		auPTS := pts + int64(i)*mpeg4audio.SamplesPerAccessUnit
 
 		err := s.fmp4WriteSample(
 			track,

--- a/muxer_stream.go
+++ b/muxer_stream.go
@@ -587,7 +587,7 @@ func (s *muxerStream) generateAndCacheInitFile() error {
 	for _, track := range s.tracks {
 		init.Tracks = append(init.Tracks, &fmp4.InitTrack{
 			ID:        trackID,
-			TimeScale: fmp4TimeScale(track.Codec),
+			TimeScale: uint32(track.ClockRate),
 			Codec:     toFMP4(track.Codec),
 		})
 		trackID++

--- a/muxer_test.go
+++ b/muxer_test.go
@@ -1069,6 +1069,71 @@ func TestMuxerCodecs(t *testing.T) {
 	}
 }
 
+func TestMuxerRejectsInvalidClockRate(t *testing.T) {
+	cases := []struct {
+		name    string
+		track   *Track
+		errorRe string
+	}{
+		{
+			name:    "h264",
+			track:   &Track{Codec: &codecs.H264{SPS: testH264SPS, PPS: []byte{0x08}}, ClockRate: 1},
+			errorRe: "track 0 requires clock rate 90000, but is 1",
+		},
+		{
+			name:    "h265",
+			track:   &Track{Codec: &codecs.H265{VPS: testH265VPS, SPS: testH265SPS, PPS: testH265PPS}, ClockRate: 1},
+			errorRe: "track 0 requires clock rate 90000, but is 1",
+		},
+		{
+			name:    "av1",
+			track:   &Track{Codec: &codecs.AV1{SequenceHeader: testAV1SequenceHeader}, ClockRate: 1},
+			errorRe: "track 0 requires clock rate 90000, but is 1",
+		},
+		{
+			name:    "vp9",
+			track:   &Track{Codec: &codecs.VP9{}, ClockRate: 1},
+			errorRe: "track 0 requires clock rate 90000, but is 1",
+		},
+		{
+			name:    "opus",
+			track:   &Track{Codec: &codecs.Opus{ChannelCount: 2}, ClockRate: 1},
+			errorRe: "track 0 requires clock rate 48000, but is 1",
+		},
+		{
+			name:    "mpeg4_audio",
+			track:   &Track{Codec: &codecs.MPEG4Audio{Config: testAACConfig}, ClockRate: 1},
+			errorRe: "track 0 requires clock rate 44100, but is 1",
+		},
+		{
+			name: "flac",
+			track: &Track{Codec: &codecs.FLAC{
+				StreamInfo: &flac.StreamInfo{SampleRate: 44100, ChannelCount: 2, BitDepth: 16},
+			}, ClockRate: 1},
+			errorRe: "track 0 requires clock rate 44100, but is 1",
+		},
+		{
+			name:    "klv",
+			track:   &Track{Codec: &codecs.KLV{}, ClockRate: 1},
+			errorRe: "track 0 requires clock rate 90000, but is 1",
+		},
+	}
+
+	for _, ca := range cases {
+		t.Run(ca.name, func(t *testing.T) {
+			m := &Muxer{
+				Variant:            MuxerVariantFMP4,
+				SegmentCount:       3,
+				SegmentMinDuration: 1 * time.Second,
+				Tracks:             []*Track{ca.track},
+			}
+
+			err := m.Start()
+			require.EqualError(t, err, ca.errorRe)
+		})
+	}
+}
+
 func TestMuxerKLV(t *testing.T) {
 	klvTrack := &Track{
 		Codec:     &codecs.KLV{},


### PR DESCRIPTION
supporting non-standard clock rates requires some computations that we're not doing right now. Adding them is not worth the effort since it's a feature not probably used by anyone.